### PR TITLE
add box-shadow in the navbar

### DIFF
--- a/frontend/src/components/NavBar.jsx
+++ b/frontend/src/components/NavBar.jsx
@@ -26,7 +26,7 @@ const NavBar = () => {
 
 
     return (
-            <header className="fixed z-50 w-screen p-3 px-4 md:p-6 md:px-16 bg-lightCard">
+            <header className="fixed z-50 w-screen p-3 px-4 md:p-6 md:px-16 bg-lightCard shadow-md">
                 {/* desktop & tablet */}
                 <div className="hidden md:flex w-full h-full items-center justify-between">
                     <div className="flex items-center gap-2">


### PR DESCRIPTION
### Related Issue:
- https://github.com/TechieeGeeeks/JobSet/issues/28 => 2


### Summary of the commit:
- Add `box-shadow` in the _navbar_ ( so that it  differentiates _navbar_ from normal page )